### PR TITLE
changed venv instructions on README

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,9 +13,13 @@ Navigate to the backend directory and create a virtual environment to isolate de
 python -m venv venv
 ```
 Activate the virtual environment:
-- Windows:
+- Windows (in CMD):
 ```bash
-venv/Scripts/bin/activate
+venv/Scripts/activate.bat
+```
+- Windows (in Powershell):
+```bash
+venv/Scripts/Activate.ps1
 ```
 - MacOS/Linux:
 ```bash


### PR DESCRIPTION
For some reason, python venv got rid of the `bin` folder (at least on Windows). So now `venv/Scripts/bin/activate` doesn't work anymore. I updated the README to reflect these changes.